### PR TITLE
Feature/#47 - injectAsync()

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vitest": "^4.0.8"
   },
   "lint-staged": {
-    "*.{js,ts,html}": "lint --cache --fix",
+    "*.{js,ts,html}": "eslint --cache --fix",
     "*.{js,ts,html,css,json,md,yml,yaml}": "prettier --write"
   }
 }

--- a/src/app/core/models/photon-query.model.ts
+++ b/src/app/core/models/photon-query.model.ts
@@ -1,0 +1,5 @@
+export interface PhotonQuery {
+  q: string;
+  lang: 'en';
+  limit: number;
+}

--- a/src/app/core/services/photon-api.service.ts
+++ b/src/app/core/services/photon-api.service.ts
@@ -13,13 +13,15 @@ export class PhotonApiService {
   public readonly user = signal<User | null>(null);
 
   public search(params: PhotonQuery): Observable<PhotonLocationSuggestion[]> {
-    return this.http.get<PhotonLocationSuggestion[]>(this.baseUrl + '/api', {
-      params: {
-        q: params.q,
-        lang: params.lang,
-        limit: params.limit
-      }
-    }).pipe(map(parsePhotonGeoJson));
+    return this.http
+      .get<PhotonLocationSuggestion[]>(this.baseUrl + '/api', {
+        params: {
+          q: params.q,
+          lang: params.lang,
+          limit: params.limit,
+        },
+      })
+      .pipe(map(parsePhotonGeoJson));
   }
 }
 
@@ -56,14 +58,22 @@ function pickCity(props: Record<string, string | undefined>): string {
   const name = (props['name'] ?? '').trim();
   if (
     name &&
-    (type === 'city' || type === 'town' || type === 'village' || type === 'locality' || type === 'district')
+    (type === 'city' ||
+      type === 'town' ||
+      type === 'village' ||
+      type === 'locality' ||
+      type === 'district')
   ) {
     return name;
   }
   return name;
 }
 
-function buildLabel(props: Record<string, string | undefined>, city: string, country: string): string {
+function buildLabel(
+  props: Record<string, string | undefined>,
+  city: string,
+  country: string,
+): string {
   const name = (props['name'] ?? '').trim();
   const parts: string[] = [];
   if (name && name.toLowerCase() !== city.toLowerCase()) {

--- a/src/app/core/services/photon-api.service.ts
+++ b/src/app/core/services/photon-api.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { User } from '../models/user.model';
+import { PhotonLocationSuggestion } from '../../shared/components/photon-location-field/photon-location-field';
+import { PhotonQuery } from '../models/photon-query.model';
+
+@Injectable({ providedIn: 'root' })
+export class PhotonApiService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = 'https://photon.komoot.io';
+
+  public readonly user = signal<User | null>(null);
+
+  public search(params: PhotonQuery): Observable<PhotonLocationSuggestion[]> {
+    return this.http.get<PhotonLocationSuggestion[]>(this.baseUrl + '/api', {
+      params: {
+        q: params.q,
+        lang: params.lang,
+        limit: params.limit
+      }
+    }).pipe(map(parsePhotonGeoJson));
+  }
+}
+
+function parsePhotonGeoJson(raw: unknown): PhotonLocationSuggestion[] {
+  const doc = raw as {
+    features?: {
+      properties?: Record<string, string | undefined>;
+    }[];
+  };
+  return (doc.features ?? [])
+    .map((f) => {
+      const props = f.properties ?? {};
+      const city = pickCity(props);
+      const country = (props['country'] ?? '').trim();
+      return { label: buildLabel(props, city, country), city, country };
+    })
+    .filter((s) => s.city && s.country);
+}
+
+function pickCity(props: Record<string, string | undefined>): string {
+  const fromAdmin = (
+    props['city'] ??
+    props['town'] ??
+    props['village'] ??
+    props['locality'] ??
+    props['district'] ??
+    props['county'] ??
+    ''
+  ).trim();
+  if (fromAdmin) {
+    return fromAdmin;
+  }
+  const type = (props['type'] ?? '').toLowerCase();
+  const name = (props['name'] ?? '').trim();
+  if (
+    name &&
+    (type === 'city' || type === 'town' || type === 'village' || type === 'locality' || type === 'district')
+  ) {
+    return name;
+  }
+  return name;
+}
+
+function buildLabel(props: Record<string, string | undefined>, city: string, country: string): string {
+  const name = (props['name'] ?? '').trim();
+  const parts: string[] = [];
+  if (name && name.toLowerCase() !== city.toLowerCase()) {
+    parts.push(name);
+  }
+  if (city) {
+    parts.push(city);
+  }
+  if (country) {
+    parts.push(country);
+  }
+  return [...new Set(parts)].join(', ');
+}

--- a/src/app/core/services/photon-api.service.ts
+++ b/src/app/core/services/photon-api.service.ts
@@ -5,7 +5,7 @@ import { User } from '../models/user.model';
 import { PhotonLocationSuggestion } from '../../shared/components/photon-location-field/photon-location-field';
 import { PhotonQuery } from '../models/photon-query.model';
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class PhotonApiService {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = 'https://photon.komoot.io';

--- a/src/app/shared/components/photon-location-field/photon-location-field.ts
+++ b/src/app/shared/components/photon-location-field/photon-location-field.ts
@@ -65,7 +65,10 @@ export class PhotonLocationField implements FormValueControl<LocationValue | nul
     { initialValue: '' },
   );
 
-  protected readonly suggestionsResource = rxResource<PhotonLocationSuggestion[], PhotonQuery | undefined>({
+  protected readonly suggestionsResource = rxResource<
+    PhotonLocationSuggestion[],
+    PhotonQuery | undefined
+  >({
     params: () => {
       const query = this.debouncedSearch();
       if (query.length < 2) return undefined;
@@ -76,12 +79,10 @@ export class PhotonLocationField implements FormValueControl<LocationValue | nul
         return of([]);
       }
 
-      return from(this.photonApiService()).pipe(
-        switchMap((service) => service.search(params)),
-      );
+      return from(this.photonApiService()).pipe(switchMap((service) => service.search(params)));
     },
     defaultValue: [],
-  })
+  });
 
   protected readonly isLoading = computed(() => {
     return this.searchInput().trim().length >= 2 && this.suggestionsResource.isLoading();

--- a/src/app/shared/components/photon-location-field/photon-location-field.ts
+++ b/src/app/shared/components/photon-location-field/photon-location-field.ts
@@ -12,6 +12,7 @@ import { debounceTime, distinctUntilChanged, from, map, of } from 'rxjs';
 import { FormValueControl, ValidationError, WithOptionalFieldTree } from '@angular/forms/signals';
 import { PhotonQuery } from '../../../core/models/photon-query.model';
 import { switchMap } from 'rxjs/operators';
+import { PhotonApiService } from '../../../core/services/photon-api.service';
 
 export interface LocationValue {
   city: string;
@@ -30,8 +31,13 @@ let nextFieldId = 0;
   selector: 'rw-photon-location-field',
   templateUrl: './photon-location-field.html',
   styleUrl: './photon-location-field.css',
+  providers: [PhotonApiService]
 })
 export class PhotonLocationField implements FormValueControl<LocationValue | null> {
+  private readonly photonApiService = injectAsync(() =>
+    import('../../../core/services/photon-api.service').then((m) => m.PhotonApiService),
+  );
+
   private readonly fieldId = `rw-photon-location-${++nextFieldId}`;
 
   // --- FormValueControl ---
@@ -51,9 +57,6 @@ export class PhotonLocationField implements FormValueControl<LocationValue | nul
   protected readonly panelOpen = signal(false);
   protected readonly activeIndex = signal(-1);
 
-  private readonly photonApiService = injectAsync(() =>
-    import('../../../core/services/photon-api.service').then((m) => m.PhotonApiService),
-  );
   private readonly searchInput = signal('');
 
   private readonly debouncedSearch = toSignal(

--- a/src/app/shared/components/photon-location-field/photon-location-field.ts
+++ b/src/app/shared/components/photon-location-field/photon-location-field.ts
@@ -1,8 +1,17 @@
-import { Component, computed, effect, input, model, signal } from '@angular/core';
-import { httpResource } from '@angular/common/http';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { debounceTime, distinctUntilChanged, map } from 'rxjs';
+import {
+  Component,
+  computed,
+  effect,
+  injectAsync,
+  input,
+  model,
+  signal,
+} from '@angular/core';
+import { rxResource, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { debounceTime, distinctUntilChanged, from, map, of } from 'rxjs';
 import { FormValueControl, ValidationError, WithOptionalFieldTree } from '@angular/forms/signals';
+import { PhotonQuery } from '../../../core/models/photon-query.model';
+import { switchMap } from 'rxjs/operators';
 
 export interface LocationValue {
   city: string;
@@ -42,6 +51,9 @@ export class PhotonLocationField implements FormValueControl<LocationValue | nul
   protected readonly panelOpen = signal(false);
   protected readonly activeIndex = signal(-1);
 
+  private readonly photonApiService = injectAsync(() =>
+    import('../../../core/services/photon-api.service').then((m) => m.PhotonApiService),
+  );
   private readonly searchInput = signal('');
 
   private readonly debouncedSearch = toSignal(
@@ -53,20 +65,23 @@ export class PhotonLocationField implements FormValueControl<LocationValue | nul
     { initialValue: '' },
   );
 
-  protected readonly suggestionsResource = httpResource<PhotonLocationSuggestion[]>(
-    () => {
+  protected readonly suggestionsResource = rxResource<PhotonLocationSuggestion[], PhotonQuery | undefined>({
+    params: () => {
       const query = this.debouncedSearch();
       if (query.length < 2) return undefined;
-      return {
-        url: 'https://photon.komoot.io/api/',
-        params: { q: query, lang: 'en', limit: '10' },
-      };
+      return { q: query, lang: 'en', limit: 10 };
     },
-    {
-      defaultValue: [],
-      parse: parsePhotonGeoJson,
+    stream: ({ params }) => {
+      if (!params) {
+        return of([]);
+      }
+
+      return from(this.photonApiService()).pipe(
+        switchMap((service) => service.search(params)),
+      );
     },
-  );
+    defaultValue: [],
+  })
 
   protected readonly isLoading = computed(() => {
     return this.searchInput().trim().length >= 2 && this.suggestionsResource.isLoading();
@@ -191,67 +206,4 @@ export class PhotonLocationField implements FormValueControl<LocationValue | nul
 
 function formatLocationLabel(location: LocationValue): string {
   return `${location.city}, ${location.country}`;
-}
-
-function pickCity(props: Record<string, string | undefined>): string {
-  const fromAdmin = (
-    props['city'] ??
-    props['town'] ??
-    props['village'] ??
-    props['locality'] ??
-    props['district'] ??
-    props['county'] ??
-    ''
-  ).trim();
-  if (fromAdmin) {
-    return fromAdmin;
-  }
-  const type = (props['type'] ?? '').toLowerCase();
-  const name = (props['name'] ?? '').trim();
-  if (
-    name &&
-    (type === 'city' ||
-      type === 'town' ||
-      type === 'village' ||
-      type === 'locality' ||
-      type === 'district')
-  ) {
-    return name;
-  }
-  return name;
-}
-
-function buildLabel(
-  props: Record<string, string | undefined>,
-  city: string,
-  country: string,
-): string {
-  const name = (props['name'] ?? '').trim();
-  const parts: string[] = [];
-  if (name && name.toLowerCase() !== city.toLowerCase()) {
-    parts.push(name);
-  }
-  if (city) {
-    parts.push(city);
-  }
-  if (country) {
-    parts.push(country);
-  }
-  return [...new Set(parts)].join(', ');
-}
-
-function parsePhotonGeoJson(raw: unknown): PhotonLocationSuggestion[] {
-  const doc = raw as {
-    features?: {
-      properties?: Record<string, string | undefined>;
-    }[];
-  };
-  return (doc.features ?? [])
-    .map((f) => {
-      const props = f.properties ?? {};
-      const city = pickCity(props);
-      const country = (props['country'] ?? '').trim();
-      return { label: buildLabel(props, city, country), city, country };
-    })
-    .filter((s) => s.city && s.country);
 }

--- a/src/app/shared/components/photon-location-field/photon-location-field.ts
+++ b/src/app/shared/components/photon-location-field/photon-location-field.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  computed,
-  effect,
-  injectAsync,
-  input,
-  model,
-  signal,
-} from '@angular/core';
+import { Component, computed, effect, injectAsync, input, model, signal } from '@angular/core';
 import { rxResource, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { debounceTime, distinctUntilChanged, from, map, of } from 'rxjs';
 import { FormValueControl, ValidationError, WithOptionalFieldTree } from '@angular/forms/signals';
@@ -31,7 +23,7 @@ let nextFieldId = 0;
   selector: 'rw-photon-location-field',
   templateUrl: './photon-location-field.html',
   styleUrl: './photon-location-field.css',
-  providers: [PhotonApiService]
+  providers: [PhotonApiService],
 })
 export class PhotonLocationField implements FormValueControl<LocationValue | null> {
   private readonly photonApiService = injectAsync(() =>


### PR DESCRIPTION
Created the PhotonApiService and injected it asynchronously into the PhotonLocationField.

**What changed:** 

- created the PhotonApiService and moved the search function inside;
- moved the utility functions _pickCity_, _buildLabel_ and _parsePhotonGeoJson_ inside too;
- injected the PhotonApiService asynchronously into the PhotonLocationField via injectAsync();
- replaced the _suggestionsResource_ from httpResource to **rxResource** to be able to use the PhotoApiService;
- cleaned some unused code and also ran Prettier formatting on the project.

The main change now allows the PhotoApiService to only be injected when it's needed - when someone starts typing to search for a location.

Closes #47 