### PR TITLE
refactor: propagate resource status via chain() and ResourceParamsStatus

### DIFF
--- a/src/app/features/cart/cart.store.ts
+++ b/src/app/features/cart/cart.store.ts
@@ -1,4 +1,4 @@
-import { signal, computed, Service } from '@angular/core';
+import { signal, computed, Service, ResourceParamsStatus } from '@angular/core';
 import { httpResource } from '@angular/common/http';
 
 export interface CartPizzeria {
@@ -51,7 +51,7 @@ export class CartStore {
     const currentPizzeria = this.pizzeria();
 
     if (currentItems.length === 0 || !currentPizzeria) {
-      return undefined;
+      throw ResourceParamsStatus.IDLE;
     }
 
     return {

--- a/src/app/features/pizzerias/pages/pizzeria-details-page/pizzeria-details-page.spec.ts
+++ b/src/app/features/pizzerias/pages/pizzeria-details-page/pizzeria-details-page.spec.ts
@@ -123,24 +123,26 @@ describe('PizzeriaDetailsPage', () => {
     }
   }
 
-  function flushInitialData(): void {
+  async function flushInitialData(): Promise<void> {
     expectPizzeriaRequest().flush(mockPizzeria);
+    await Promise.resolve();
+    TestBed.flushEffects();
     flushPizzaRequests();
   }
 
-  it('should show loading indicator before response', () => {
+  it('should show loading indicator before response', async () => {
     expect(el.querySelector('[aria-label="Loading pizzeria"]')).not.toBeNull();
-    flushInitialData();
+    await flushInitialData();
   });
 
   it('should render pizzeria name after successful responses', async () => {
-    flushInitialData();
+    await flushInitialData();
     await fixture.whenStable();
     expect(el.textContent).toContain('Roma');
   });
 
   it('should render pizza names in the catalog', async () => {
-    flushInitialData();
+    await flushInitialData();
     await fixture.whenStable();
     expect(el.textContent).toContain('Margherita');
     expect(el.textContent).toContain('Diavola');
@@ -155,6 +157,8 @@ describe('PizzeriaDetailsPage', () => {
 
   it('should load the next page when load more is triggered and more pages exist', async () => {
     expectPizzeriaRequest().flush(mockPizzeria);
+    await Promise.resolve();
+    TestBed.flushEffects();
     const page1 = httpTesting.expectOne((r) => r.url.includes('/api/pizzerias/p1/pizzas'));
     page1.flush({
       ...mockPizzasPage,
@@ -195,6 +199,8 @@ describe('PizzeriaDetailsPage', () => {
 
   it('should not request another page when load more fires while pizzas are loading', async () => {
     expectPizzeriaRequest().flush(mockPizzeria);
+    await Promise.resolve();
+    TestBed.flushEffects();
     const page1 = httpTesting.expectOne((r) => r.url.includes('/api/pizzerias/p1/pizzas'));
     page1.flush({
       ...mockPizzasPage,
@@ -236,7 +242,7 @@ describe('PizzeriaDetailsPage', () => {
   });
 
   it('should not load the next page when there are no more pages', async () => {
-    flushInitialData();
+    await flushInitialData();
     TestBed.flushEffects();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -250,6 +256,8 @@ describe('PizzeriaDetailsPage', () => {
 
   it('should show a spinner while loading more pizzas', async () => {
     expectPizzeriaRequest().flush(mockPizzeria);
+    await Promise.resolve();
+    TestBed.flushEffects();
     const page1 = httpTesting.expectOne((r) => r.url.includes('/api/pizzerias/p1/pizzas'));
     page1.flush({
       ...mockPizzasPage,
@@ -295,6 +303,8 @@ describe('PizzeriaDetailsPage', () => {
 
   it('should show empty state when no pizzas returned', async () => {
     expectPizzeriaRequest().flush(mockPizzeria);
+    await Promise.resolve();
+    TestBed.flushEffects();
     httpTesting
       .match((r) => r.url.includes('/api/pizzerias/p1/pizzas'))
       .forEach((r) => r.flush({ items: [], total: 0, page: 1, limit: 8, totalPages: 0 }));
@@ -303,15 +313,17 @@ describe('PizzeriaDetailsPage', () => {
   });
 
   describe('maxPrice filter', () => {
-    it('should not send maxPrice param at default value', () => {
+    it('should not send maxPrice param at default value', async () => {
       expectPizzeriaRequest().flush(mockPizzeria);
+      await Promise.resolve();
+      TestBed.flushEffects();
       const req = httpTesting.expectOne((r) => r.url.includes('/api/pizzerias/p1/pizzas'));
       expect(req.request.params.has('maxPrice')).toBe(false);
       req.flush(mockPizzasPage);
     });
 
     it('should include maxPrice param when maxPrice is changed', async () => {
-      flushInitialData();
+      await flushInitialData();
       TestBed.flushEffects();
       fixture.detectChanges();
       await fixture.whenStable();
@@ -336,7 +348,7 @@ describe('PizzeriaDetailsPage', () => {
     });
 
     it('should include maxPrice param when name is also changed', async () => {
-      flushInitialData();
+      await flushInitialData();
       TestBed.flushEffects();
       fixture.detectChanges();
       await fixture.whenStable();
@@ -364,7 +376,7 @@ describe('PizzeriaDetailsPage', () => {
     });
 
     it('should sync maxPrice to URL query params', async () => {
-      flushInitialData();
+      await flushInitialData();
       TestBed.flushEffects();
       fixture.detectChanges();
       await fixture.whenStable();
@@ -392,15 +404,17 @@ describe('PizzeriaDetailsPage', () => {
   });
 
   describe('name search filter', () => {
-    it('should not send name param when search is empty', () => {
+    it('should not send name param when search is empty', async () => {
       expectPizzeriaRequest().flush(mockPizzeria);
+      await Promise.resolve();
+      TestBed.flushEffects();
       const req = httpTesting.expectOne((r) => r.url.includes('/api/pizzerias/p1/pizzas'));
       expect(req.request.params.has('name')).toBe(false);
       req.flush(mockPizzasPage);
     });
 
     it('should include name param after setting a search value', async () => {
-      flushInitialData();
+      await flushInitialData();
       TestBed.flushEffects();
       fixture.detectChanges();
       await fixture.whenStable();
@@ -418,7 +432,7 @@ describe('PizzeriaDetailsPage', () => {
     });
 
     it('should trim whitespace from search name', async () => {
-      flushInitialData();
+      await flushInitialData();
       TestBed.flushEffects();
       fixture.detectChanges();
       await fixture.whenStable();

--- a/src/app/features/pizzerias/pages/pizzeria-details-page/pizzeria-details-page.ts
+++ b/src/app/features/pizzerias/pages/pizzeria-details-page/pizzeria-details-page.ts
@@ -90,6 +90,7 @@ export class PizzeriaDetailsPage {
 
   protected readonly pizzasResource = this.pizzeriaApi.getPizzeriaPizzasResource(
     this.id,
+    this.pizzeriaResource,
     this.page,
     this.filterParams,
   );

--- a/src/app/features/pizzerias/pages/pizzeria-list-page/pizzeria-list-page.ts
+++ b/src/app/features/pizzerias/pages/pizzeria-list-page/pizzeria-list-page.ts
@@ -4,6 +4,7 @@ import {
   computed,
   debounced,
   inject,
+  linkedSignal,
   signal,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
@@ -46,13 +47,17 @@ export class PizzeriaListPage {
   );
 
   // Pagination
-  protected readonly currentPage = signal(1);
+  protected readonly currentPage = linkedSignal({
+    source: this.debouncedSearch.value,
+    computation: () => 1,
+  });
   protected readonly limit = 12;
 
   protected readonly pizzeriasResource = this.pizzeriaApi.getPizzeriaListResource(
     this.currentPage,
     this.limit,
     this.debouncedSearch.value,
+    this.searchInput,
   );
 
   protected changePage(page: number): void {

--- a/src/app/features/pizzerias/services/pizzeria-api.ts
+++ b/src/app/features/pizzerias/services/pizzeria-api.ts
@@ -1,4 +1,4 @@
-import { inject, Signal, ResourceRef, Service } from '@angular/core';
+import { inject, Signal, ResourceRef, ResourceParamsStatus, Service } from '@angular/core';
 import { HttpClient, httpResource } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Page } from '../../../core/models/pagination.model';
@@ -51,23 +51,31 @@ export class PizzeriaApi {
     page: Signal<number>,
     limit: number,
     search: Signal<string>,
+    pendingSearch: Signal<string>,
   ): ResourceRef<Page<PizzeriaSummary> | undefined> {
-    return httpResource<Page<PizzeriaSummary>>(() => ({
-      url: '/api/pizzerias',
-      params: {
-        page: search() ? 1 : page(),
-        limit,
-        ...(search() ? { search: search() } : {}),
-      },
-    }));
+    return httpResource<Page<PizzeriaSummary>>(() => {
+      if (pendingSearch().trim() !== search()) {
+        throw ResourceParamsStatus.LOADING;
+      }
+      return {
+        url: '/api/pizzerias',
+        params: {
+          page: page(),
+          limit,
+          ...(search() ? { search: search() } : {}),
+        },
+      };
+    });
   }
 
   public getPizzeriaPizzasResource(
     pizzeriaId: Signal<string>,
+    pizzeriaResource: ResourceRef<PizzeriaDetail | undefined>,
     page: Signal<number>,
     filterParams: Signal<Record<string, string | number | boolean>>,
   ): ResourceRef<Page<Pizza> | undefined> {
-    return httpResource<Page<Pizza>>(() => {
+    return httpResource<Page<Pizza>>(({ chain }) => {
+      chain(pizzeriaResource);
       return {
         url: `/api/pizzerias/${pizzeriaId()}/pizzas`,
         params: {


### PR DESCRIPTION
- chain pizzasResource to pizzeriaResource to forward idle/loading/error states
- throw ResourceParamsStatus.IDLE in cartResource instead of returning undefined
- throw ResourceParamsStatus.LOADING in pizzeriasResource while debounce is pending
- reset currentPage to 1 on search change via linkedSignal for pagination to work properly if there is search input
- yield one microtask in PizzeriaDetailsPage tests after flushing pizzeria response before accessing pizza requests, since chain() defers the pizza resource's HTTP request until the async loadEffect continuation resolves