### PR TITLE
refactor: unmatchedInputBehavior: 'undefinedIfStale' added #51

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -15,7 +15,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(
       routes,
-      withComponentInputBinding(),
+      withComponentInputBinding({ unmatchedInputBehavior: 'undefinedIfStale' }),
       withExperimentalAutoCleanupInjectors(),
       withInMemoryScrolling({
         scrollPositionRestoration: 'enabled',


### PR DESCRIPTION
This pull request makes a minor adjustment to the router configuration in `app.config.ts`. The change specifies the behavior for unmatched component input bindings to return `undefined` if the input is stale, which can help prevent errors from outdated values during navigation.

- Routing configuration:
  * Updated `withComponentInputBinding` to use `{ unmatchedInputBehavior: 'undefinedIfStale' }` for safer handling of unmatched inputs.