### PR TITLE
Refactor/input type numbet to type text inputmode decimal#37

### DIFF
--- a/.agents/skills/angular-developer/references/signal-forms.md
+++ b/.agents/skills/angular-developer/references/signal-forms.md
@@ -667,7 +667,7 @@ export class App {
 
     <label>
       Age
-      <input type="number" [formField]="bookingForm.personalInfo.age" />
+      <input type="text" inputmode="decimal" [formField]="bookingForm.personalInfo.age" />
       @if (bookingForm.personalInfo.age().touched() &&
       bookingForm.personalInfo.age().errors().length) {
       <span>{{ bookingForm.personalInfo.age().errors()[0].message }}</span>

--- a/src/app/features/checkout/components/checkout-review-step/checkout-review-step.html
+++ b/src/app/features/checkout/components/checkout-review-step/checkout-review-step.html
@@ -126,7 +126,8 @@
   @if (wizard.checkoutForm.tip.type().value() === 'custom') {
     <rw-input
       label="Tip amount (€)"
-      type="number"
+      type="text"
+      inputmode="decimal"
       [formField]="wizard.checkoutForm.tip.customAmount"
       placeholder="0.00"
     />

--- a/src/app/features/orders/components/pizza-order-form-dialog/pizza-order-form-dialog.html
+++ b/src/app/features/orders/components/pizza-order-form-dialog/pizza-order-form-dialog.html
@@ -58,7 +58,13 @@
           >
             <img ngSrc="/icons/remove.svg" alt="" width="24" height="24" aria-hidden="true" />
           </button>
-          <rw-input class="quantity-input" type="number" [formField]="orderForm.quantity" />
+
+          <rw-input
+            class="quantity-input"
+            type="text"
+            inputmode="decimal"
+            [formField]="orderForm.quantity"
+          />
           <button
             type="button"
             class="quantity-btn"

--- a/src/app/features/pizzerias/components/admin-pizza-form-dialog/admin-pizza-form-dialog.html
+++ b/src/app/features/pizzerias/components/admin-pizza-form-dialog/admin-pizza-form-dialog.html
@@ -14,7 +14,12 @@
       "
     />
 
-    <rw-input label="Base price (€)" type="number" [formField]="pizzaForm.basePrice" />
+    <rw-input
+      label="Base price (€)"
+      type="text"
+      inputmode="decimal"
+      [formField]="pizzaForm.basePrice"
+    />
 
     <rw-image-picker category="pizza" label="Pizza image" [formField]="pizzaForm.image" />
 

--- a/src/app/shared/components/input/input.html
+++ b/src/app/shared/components/input/input.html
@@ -9,6 +9,7 @@
     <div class="field__control">
       <input
         [type]="type()"
+        [attr.inputmode]="inputmode()"
         [placeholder]="placeholder()"
         [formField]="formField()"
         [attr.autocomplete]="autocomplete() ?? null"

--- a/src/app/shared/components/input/input.ts
+++ b/src/app/shared/components/input/input.ts
@@ -14,4 +14,5 @@ export class Input {
   public readonly hint = input<string>('');
   public readonly autocomplete = input<string | undefined>(undefined);
   public readonly formField = input.required<FieldTree<string | number | null>>();
+  public readonly inputmode = input<string>();
 }


### PR DESCRIPTION
Swap type="number" for type="text" inputmode="decimal" on the three numeric fields (basePrice, quantity, tip.customAmount), and forward inputmode through the shared rw-input wrapper.

Motivation: addresses issue #37, following Angular commit 41b1410 (Signal Forms now supports binding number|null to <input type="text">); type="number" has known UX drawbacks; inputmode alone on the call site had no effect because rw-input didn't forward it to the inner <input>.