### PR TITLE
feat: add debounce on email validation to prevent HTTP requests durin…

### DIFF
--- a/src/app/features/auth/pages/register-page/register-page.spec.ts
+++ b/src/app/features/auth/pages/register-page/register-page.spec.ts
@@ -43,4 +43,25 @@ describe('RegisterPage', () => {
     await fixture.whenStable();
     expect(fixture.componentInstance.registerAsPizzeriaOwner()).toBe(true);
   });
+
+  it('should not trigger HTTP validation while typing email character by character', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const emailInput = el.querySelector('input[type="email"]') as HTMLInputElement;
+    expect(emailInput).not.toBeNull();
+
+    // Type email character by character
+    const emailChars = 'test@example.com'.split('');
+    for (const char of emailChars) {
+      emailInput.value += char;
+      emailInput.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+    }
+
+    await fixture.whenStable();
+
+    // Should not have made any HTTP requests during typing
+    httpTesting.expectNone((req) => req.url.includes('/api/auth/check-email'));
+  });
 });

--- a/src/app/features/auth/pages/register-page/register-page.ts
+++ b/src/app/features/auth/pages/register-page/register-page.ts
@@ -10,6 +10,7 @@ import {
   validateTree,
   validateHttp,
   FormRoot,
+  debounce,
 } from '@angular/forms/signals';
 import { Auth } from '../../../../core/services/auth';
 import { Callout } from '../../../../shared/components/callout/callout';
@@ -35,6 +36,7 @@ export class RegisterPage {
     (schema) => {
       required(schema.email, { message: 'Email is required' });
       email(schema.email, { message: 'Enter a valid email' });
+      debounce(schema.email, 'blur');
       validateHttp(schema.email, {
         request: (ctx) =>
           ctx.value()


### PR DESCRIPTION
This pull request enhances the email validation experience on the registration page by ensuring that HTTP validation is only triggered when the email input loses focus, rather than on every keystroke. It also adds a test to verify this behavior.

**Email validation improvements:**

* Applied the `debounce` function to the email field with the `'blur'` event, so HTTP validation is only triggered when the user leaves the email input, reducing unnecessary network requests and improving performance. [[1]](diffhunk://#diff-d039d15d9dab9edf4c9585a3f852a49896d54aae659db98bd65d8d906e8f6806R13) [[2]](diffhunk://#diff-d039d15d9dab9edf4c9585a3f852a49896d54aae659db98bd65d8d906e8f6806R39)

**Testing enhancements:**

* Added a test to ensure that typing an email character by character does not trigger HTTP validation requests, confirming the debounce behavior.…g input 'blur' option to debounce rule #26